### PR TITLE
Fix plugin context dependency on configured order

### DIFF
--- a/castervoice/__main__.py
+++ b/castervoice/__main__.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG_DIR = "config"
 
 
 def default_plugin_state_dir(config_dir):
-    return "{}/plugins.state".format(config_dir)
+    return f"{config_dir}/plugins.state"
 
 
 def _on_begin():
@@ -24,9 +24,9 @@ def _on_begin():
 
 
 def _on_recognition(words, rule, node):
-    print(u"Recognized: %s" % u" ".join(words))
-    print(u"    Executing rule: %s" % (rule))
-    print(u"    Action: %s" % (node.value()))
+    print("Recognized: " + " ".join(words))
+    print("    Executing rule: " + str(rule))
+    print("    Action: " + str(node.value()))
 
 
 def _on_failure():
@@ -50,8 +50,8 @@ def get_parser():
                              'subdirectory within `config_dir`.')
 
     parser.add_argument('--verbose', '-v', action='count',
-                        default=0, help='Verbose logging (max level: %s).'
-                        % len(VERBOSITY_LOG_LEVEL))
+                        default=0, help=f'Verbose logging (max level:\
+                                          {len(VERBOSITY_LOG_LEVEL)}).')
 
     return parser
 

--- a/castervoice/core/context.py
+++ b/castervoice/core/context.py
@@ -75,11 +75,9 @@ class PluginContext(Context):
         except Exception as error:  # pylint: disable=W0703
             self.manager.log.exception(
                     "Error while applying plugin specific"
-                    " context in context '%s'."
+                    f" context in context '{self._name}'."
                     " Unable to get context for plugin"
-                    " %s: %s" % (self._name,
-                                 self._plugin_id,
-                                 error))
+                    f" {self._plugin_id}: {error}")
 
     def matches(self, executable, title, handle):
         if not self._loaded:

--- a/castervoice/core/context.py
+++ b/castervoice/core/context.py
@@ -7,18 +7,32 @@ from dragonfly import (
 
 class Context(DragonflyContext):
 
-    """Docstring for myclass. """
-
-    def __init__(self, manager, config):
+    def __init__(self, name, manager):
         """TODO: to be defined. """
 
         super().__init__()
 
-        self._str = config.pop("name")
+        self._str = name
         self._name = self._str
         self._enabled = True
 
         self._contexts = []
+
+        self.manager = manager
+
+    def matches(self, executable, title, handle):
+        return self._enabled and LogicAndContext(*self._contexts) \
+            .matches(executable, title, handle)
+
+
+class ConfigContext(Context):
+
+    """Interpret context from Caster configuration"""
+
+    def __init__(self, manager, config):
+        """TODO: to be defined. """
+
+        super().__init__(config.pop("name"), manager)
 
         executable = config.pop("executable", None)
         title = config.pop("title", None)
@@ -28,18 +42,48 @@ class Context(DragonflyContext):
 
         # Apply plugin specific contexts
         for plugin_id, desired_state in config.items():
-            try:
-                plugin_context = manager.get_plugin_context(plugin_id,
-                                                            desired_state)
-                self._contexts.append(plugin_context)
 
-            except Exception as error:  # pylint: disable=W0703
-                manager.log.exception("Error while applying plugin specific"
-                                      " context in context '%s'."
-                                      " Unable to get context for plugin"
-                                      " %s: %s" % (self._name, plugin_id,
-                                                   error))
+            self._contexts.append(
+                    PluginContext(manager, plugin_id, desired_state))
+
+
+class PluginContext(Context):
+
+    """Lazily loads plugin contexts on matching
+
+    Plugin contexts may not be available at start up
+    while plugins are still loaded sequentially.
+
+    """
+
+    def __init__(self, manager, plugin_id, desired_state):
+
+        super().__init__(plugin_id, manager)
+
+        self._plugin_id = plugin_id
+        self._desired_state = desired_state
+
+        self._loaded = False
+
+    def load(self):
+        try:
+            plugin_context = self.manager \
+                .get_plugin_context(self._plugin_id,
+                                    self._desired_state)
+            self._contexts.append(plugin_context)
+
+        except Exception as error:  # pylint: disable=W0703
+            self.manager.log.exception(
+                    "Error while applying plugin specific"
+                    " context in context '%s'."
+                    " Unable to get context for plugin"
+                    " %s: %s" % (self._name,
+                                 self._plugin_id,
+                                 error))
 
     def matches(self, executable, title, handle):
-        return self._enabled and LogicAndContext(*self._contexts) \
-            .matches(executable, title, handle)
+        if not self._loaded:
+            self.load()
+            self._loaded = True
+
+        return super().matches(executable, title, handle)

--- a/castervoice/core/context_manager.py
+++ b/castervoice/core/context_manager.py
@@ -2,7 +2,7 @@ import logging
 
 from dragonfly.grammar.context import LogicOrContext, LogicAndContext
 
-from castervoice.core.context import Context
+from castervoice.core.context import ConfigContext
 
 
 class ContextManager():
@@ -45,7 +45,7 @@ class ContextManager():
             context_plugins = context_config.pop("plugins", [])
             extends = context_config.pop("extends", None)
 
-            context = Context(self, context_config)
+            context = ConfigContext(self, context_config)
 
             if isinstance(extends, str):
                 extended_context = self._contexts.get(extends)

--- a/castervoice/core/controller.py
+++ b/castervoice/core/controller.py
@@ -86,12 +86,13 @@ class Controller:
 
         if isinstance(config_dir, str):
             try:
-                with open(config_dir + "/caster.yml", "r") as ymlfile:
+                with open(config_dir + "/caster.yml", "r",
+                          encoding="utf-8") as ymlfile:
                     config_from_file = yaml.load(ymlfile, Loader=Loader)
                     if config_from_file is not None:
                         config_result.update(config_from_file)
             except yaml.YAMLError as error:
-                print("Error in configuration file: {}".format(error))
+                print(f"Error in configuration file: {error}")
             except FileNotFoundError as error:
                 self.log.info("Configuration file was not found in specified "
                               "path '%s': %s ",
@@ -101,7 +102,7 @@ class Controller:
                 return self.load_config(config, config_dir)
 
         if "plugins" not in config_result:
-            config_result["plugins"] = dict()
+            config_result["plugins"] = {}
         if "contexts" not in config_result:
             config_result["contexts"] = []
 
@@ -112,12 +113,13 @@ class Controller:
 
             if not os.path.isdir(os.path.dirname(config_dir)):
                 raise FileNotFoundError("Configuration directory base path "
-                                        "'%s' does not exist!" %
-                                        os.path.dirname(config_dir))
+                                        f"'{os.path.dirname(config_dir)}'"
+                                        "does not exist!")
 
             os.mkdir(config_dir)
 
-        with open(config_dir + "/caster.yml", 'w') as config_file:
+        with open(config_dir + "/caster.yml", 'w', encoding="utf-8") \
+                as config_file:
             config_file.write(pkg_resources.read_text(casterconfig,
                                                       'caster.yml'))
 
@@ -135,8 +137,8 @@ class Controller:
                 break
 
         if engine_config is None:
-            raise ValueError("Missing `engine` configuration! Received '%s'"
-                             % self._config["engine"])
+            raise ValueError("Missing `engine` configuration! Received "
+                             f"'{self._config['engine']}'")
 
         dragonfly_engine = engine_config.get('options', {})
         dragonfly_engine.update(dict([('name', engine_type)]))

--- a/castervoice/core/controller.py
+++ b/castervoice/core/controller.py
@@ -131,6 +131,9 @@ class Controller:
         :returns: Engine object
         """
 
+        if 'engine' not in self._config:
+            raise ValueError("Missing `engine` entry in configuration file!")
+
         for engine_type in ['kaldi', 'natlink', 'sapi5', 'text']:
             engine_config = self._config["engine"].get(engine_type)
             if engine_config is not None:

--- a/castervoice/core/dependency_manager.py
+++ b/castervoice/core/dependency_manager.py
@@ -71,9 +71,9 @@ class ModuleReloader(importlib.abc.MetaPathFinder):
         # 'casterplugin.dictation') and value contains the entries
         # `module` (module object) and `dependencies`
         # (list of modules which the module depends on)
-        self._modules = dict()
+        self._modules = {}
 
-        self.watched_plugin_modules = dict()
+        self.watched_plugin_modules = {}
 
         get_current_engine().create_timer(self.reload, 10)
 
@@ -114,11 +114,11 @@ class ModuleReloader(importlib.abc.MetaPathFinder):
                     except AttributeError:
                         m = sys.modules[m.__name__ + '.' + component]
 
-            module = self._modules.setdefault(name, dict())
+            module = self._modules.setdefault(name, {})
             module["module"] = m
 
             if parent is not None:
-                parent_module = self._modules.setdefault(parent, dict())
+                parent_module = self._modules.setdefault(parent, {})
                 # If this is a nested import for a reloadable (source-based)
                 # module, we append ourself to our parent's dependency list.
                 if hasattr(m, '__file__'):

--- a/castervoice/core/plugin/plugin.py
+++ b/castervoice/core/plugin/plugin.py
@@ -25,7 +25,7 @@ class Plugin():
 
         self._id = self.__class__.__module__
         class_name = self.__class__.__name__
-        self._name = "{}.{}".format(self._id, class_name)
+        self._name = f"{self._id}.{class_name}"
 
         self._manager = manager
         self._loaded = False
@@ -37,7 +37,7 @@ class Plugin():
         if self._manager and self._manager.state_directory:
             self._state = PluginState(os.path
                                       .join(self._manager.state_directory,
-                                            "%s.state" % (self._id)))
+                                            "{self._id}.state"))
 
         self._init_context()
 
@@ -47,8 +47,8 @@ class Plugin():
     name = property(lambda self: self._name,
                     doc="Plugin name.")
 
-    log = property(lambda self: logging.getLogger("castervoice.Plugin({})"
-                                                  .format(self._name)),
+    log = property(lambda self:
+                   logging.getLogger("castervoice.Plugin({self._name})"),
                    doc="Get class logger.")
 
     def set_state(self, data):
@@ -150,8 +150,8 @@ class Plugin():
 
         """
 
-        raise NotImplementedError("Plugin '%s' does not provide any"
-                                  " contexts" % (self._name))
+        raise NotImplementedError(f"Plugin '{self._name}' does not provide any"
+                                  " contexts")
 
     def apply_context(self, context=None):
         if context is not None:
@@ -182,10 +182,11 @@ class PluginFile:
         self._type = self.__class__.__name__
 
         try:
-            with open(file_path, "r") as ymlfile:
+            with open(file_path, "r", encoding="utf-8") as ymlfile:
                 self._data = yaml.load(ymlfile, Loader=Loader)
         except yaml.YAMLError as error:
-            print("Error in {} file: {}".format(self._type, error))
+            print("Error in {self._type} file:")
+            print(error)
         except FileNotFoundError:
             pass
 
@@ -205,5 +206,5 @@ class PluginState(PluginFile):
         super().__init__(file_path)
 
     def persist(self):
-        with open(self._file_path, 'w') as ymlfile:
+        with open(self._file_path, 'w', encoding="utf-8") as ymlfile:
             ymlfile.write(yaml.dump(self._data, Dumper=Dumper))

--- a/castervoice/core/plugin/plugin_manager.py
+++ b/castervoice/core/plugin/plugin_manager.py
@@ -41,9 +41,9 @@ class PluginManager():
             if not os.path.exists(self._state_directory):
                 os.mkdir(self._state_directory)
             elif not os.path.isdir(self._state_directory):
-                raise NotADirectoryError("State directory '%s' must be a"
-                                         " directory!"
-                                         % (self._state_directory))
+                raise NotADirectoryError("State directory"
+                                         f" '{self._state_directory}'"
+                                         " must be a directory!")
 
         self._init_plugins(config)
 


### PR DESCRIPTION


Previously plugins were loaded in the order
they appeared in the configuration file and at
the same time plug in context references were
resolved and loaded.

This led to the error that when a plug in required
a context from a not yet loaded plugin the loading
sequence failed.

Now plug in contexts are loaded lazily.
