### PR TITLE
Improve documentation towards releasing prototype

### DIFF
--- a/docs/source/about/transition.rst
+++ b/docs/source/about/transition.rst
@@ -4,3 +4,13 @@ Transition to Caster3
 .. note::
 
     Work in progress
+
+Differences to Caster2
+----------------------
+
+* Caster3 is modular. `caster-core` supplies usability features while the actual grammars and rules for speech recognition are supplied by plugins.
+* The focus of Caster3 is to provide the glue which holds together speech recognition engines and speech recognition frameworks.
+  While speech recognition frameworks such as Dragonfly tightly couple speech recognition engines, grammars and bound actions Caster3
+  seeks to find a lighter coupling between these components.
+  This allows Caster3 to focus on usability.
+

--- a/docs/source/development/plugin.rst
+++ b/docs/source/development/plugin.rst
@@ -2,5 +2,5 @@ Plugin
 ======
 
 .. automodule:: castervoice.core.plugin
-   :members: Plugin
+   :members: Plugin,PluginManager
    :noindex:

--- a/docs/source/development/plugin_manager.rst
+++ b/docs/source/development/plugin_manager.rst
@@ -1,6 +1,0 @@
-Plugin Manager
-==============
-
-.. automodule:: castervoice.core.plugin
-   :members: PluginManager
-   :noindex:

--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -13,19 +13,19 @@ Plugins
 Plugins can be used by adding plugin packages to the :doc:`configuration file</configuration>` which are installed
 automatically when *Caster* starts.
 
-For example, the following will install `Timoses Caster Plugins`_ package:
+For example, the following will install `CasterVoice Caster Plugins`_ package:
 
 
-.. _Timoses Caster Plugins: https://github.com/Timoses/caster-timoses
+.. _CasterVoice Caster Plugins: https://github.com/CasterVoice/caster-plugins
 
 .. code-block:: yaml
 
     plugins:
       packages:
-        - pip: "git+https://github.com/Timoses/caster-plugins.git"
+        - pip: "git+https://github.com/CasterVoice/caster-plugins.git"
 
 
-Once the package is included its plugins can be referenced in plugin list of a context section within the :doc:`configuration file</configuration>` like so:
+Once the package is included its plugins can be referenced in the plugins list of a context section within the :doc:`configuration file</configuration>` like so:
 
 .. code-block:: yaml
 
@@ -33,4 +33,4 @@ Once the package is included its plugins can be referenced in plugin list of a c
     contexts:
       - name: global
         plugins:
-          - castercontrol
+          - casterplugin.castercontrol

--- a/docs/source/plugin/1_feature.rst
+++ b/docs/source/plugin/1_feature.rst
@@ -15,4 +15,4 @@ Note that stored data is presently not encrypted.
 Configuration
 -------------
 
-Plugins can themselves define how they may be configured by the user.
+Plugins can themselves define how they may be :doc:`configured </configuration>` by the user.


### PR DESCRIPTION


LexiconCode stated the following:

    I think presenting it as a possible rewrite in the caster channel for "design" feedback would be appropriate.
    In order to do that you're going to have to state that only the goals of the design of core and plug-ins which should be simple but also its known limitations. I can spend time filling out more of questions (some of which we have discussed) below but it's meant to give you an idea of some things people might ask.
    However I doubt a lot of feedback will occur as the caster channel represents more users than developers in the classical sense.

    How does a plug-in differ from a rule?
    Does caster-core work with all current engines?
    Caster-core handle dragonfly function context?
    Equivalent to companion rules exist?
    If plug-ins are not meant to be edited by the end-user how are they customized?
    Where are the plug-ins stored and how are they installed?
    Does CCR work as expected with extras, default rather than just repetition?
    What happens when CCR rules have identical specs?
    Are current rules backwards compatible and why not?
    Can we package multiple plug-ins in one repository that can be installed separately?
    Are plug-in dependencies isolated/separate from other plug-in dependencies?
    People are foremost going to be concerned about ease-of-use over design. They will care about design only if it impedes ease-of-use. In order for it to become a viable rewrite it has to replace existing functionality of the current project even if it doesn't share the same design. In other words isn't just an issue of packaging rules into plug-ins but plug-in ecosystem (Not grammars/rules) and caster core framework needs to be capable of emulating existing features. We want to transition the community. To push this too early without feature equivalents would cause a split in the community one that we could not afford. Managing the caster project has been tough over the last 5 years. I have had to care about the entire project not just the parts that interest me. That has been a real challenge and forced me to grow in very limited time available for me to contribute.

    A quick thought on design I think caster core should handle to concepts plug-ins and extensions.

    Plug-ins always contain voice grammars and non-shareable code
    Extensions are meant to be utilized by plug-ins but do not contain voice grammars. They would extend functionality beyond caster-core and to be listed as dependencies of plug-ins. Plug-ins only rely on extensions and not other plug-ins. Extensions should be caster core version agnostic.
    Extensions could be easily PIP installable. Plug-ins I'm not fully convinced on pip as a primary means of installation.

Above points should be considered.




I don't think we are there yet to create a community release. There's still so much to design and work out.

I think the first step would be a 'prototype' release.

So these documentation changes are once again a little step towards a better access towards the prototype.



